### PR TITLE
Add config for test framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,10 @@ jobs:
         run: pip install .[dev]
 
       - name: Run tests
-        run: pytest
+        run: pytest --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version && success()
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  release:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install .[dev]
+
+      - name: Run tests
+        run: pytest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.rulers": [
+            88
+        ]
+    },
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/ImperialCollegeLondon/FINESSE_processing/main.svg)](https://results.pre-commit.ci/latest/github/ImperialCollegeLondon/FINESSE_processing/main)
+[![codecov](https://codecov.io/gh/ImperialCollegeLondon/FINESSE_processing/graph/badge.svg?token=DTS433S9E2)](https://codecov.io/gh/ImperialCollegeLondon/FINESSE_processing)
 
 ## Badges
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/ImperialCollegeLondon/FINESSE_processing/main.svg)](https://results.pre-commit.ci/latest/github/ImperialCollegeLondon/FINESSE_processing/main)
 [![codecov](https://codecov.io/gh/ImperialCollegeLondon/FINESSE_processing/graph/badge.svg?token=DTS433S9E2)](https://codecov.io/gh/ImperialCollegeLondon/FINESSE_processing)
+[![CI](https://github.com/ImperialCollegeLondon/FINESSE_processing/actions/workflows/ci.yml/badge.svg)](https://github.com/ImperialCollegeLondon/FINESSE_processing/actions/workflows/ci.yml)
 
 ## Badges
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# Don't fail CI if coverage drops
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dev = [
     "ruff",
     "tox",
     "myst_parser",
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
 ]
 publishing = ["build", "twine", "wheel"]
 
@@ -78,6 +81,9 @@ pydocstyle.convention = "google"
 
 # Ignore scripts as they'll be refactored soon. This can be removed at some point.
 "Python_code_multi/*" = ["ALL"]
+
+[tool.pytest.ini_options]
+addopts = "-v -p no:warnings --cov=src/finesse_processing --cov-report=html --doctest-modules --ignore=Python_code_multi"
 
 [tool.bumpversion]
 current_version = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = []
 description = "Code for calibrating FINESSE interferograms"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for FINESSE processing."""

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,14 @@
+"""This file contains an example unit test.
+
+pytest will search for tests in any file whose name begins with "test_". Tests are just
+functions containing assert statements; their names must also start with "test_".
+
+Feel free to delete this file when there are actual unit tests in this folder.
+"""
+
+from finesse_processing import __version__
+
+
+def test_version():
+    """Check that the version is acceptable."""
+    assert __version__ == "0.1.0"


### PR DESCRIPTION
This PR adds the config files for the test framework, using `pytest`. You can use it either by running `pytest` directly from your terminal (after installing the project dependencies) or through VS Code's test panel. I added an example unit test.

It also adds configuration so we can track test coverage with [codecov](https://about.codecov.io/). Now when you open a PR it will tell you if any new lines of code aren't covered by tests, which is useful to know.

Closes #9.