### PR TITLE
Add script dependencies to `pyproject.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Next you will want to install the dependencies for `FINESSE_processing` along wi
 You can do this like so:
 
 ```sh
-pip install -e .[dev]
+pip install -e .[dev,scripts]
 ```
 
 ### Install `pre-commit`

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ The details of how these scripts are going to be sorted are in the projects work
 
 Here is a description of what each of the files currently does:
 
-- **File 0**  is just reading the sensors to track BB temperatures, PRT sensors and vaisala instrument pressure temperutre humidity + co2
+- **File 0**  is just reading the sensors to track BB temperatures, PRT sensors and vaisala instrument pressure temperature humidity + co2
 
 - **File 1**  is preparing the interferograms for single or multi (averaged 40)
 
 - **File 2** is calculating the response functions (always done in multi case)
 
 - **File 3a single** is doing calibration for multi case [NOTE THIS CODE IS NOT FINISHED]
-- **File 3b mulit**  is doing calibration for single case
+- **File 3b multi**  is doing calibration for single case
 
 **Quick plot file:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ select = [
     "I",   # isort
     "UP",  # pyupgrade
     "RUF", # ruff
+    "NPY", # numpy
 ]
 pydocstyle.convention = "google"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "tox",
     "myst_parser",
 ]
+scripts = ["cycler", "matplotlib", "numpy>=2", "pandas", "scipy"]
 publishing = ["build", "twine", "wheel"]
 
 [project.urls]


### PR DESCRIPTION
We want to make it as easy for users/developers to get started, so we don't want people to have to manually install extra dependencies, so I've added a new `scripts` group of dependencies for the ones needed for the scripts. We can move them over to the main `dependencies` list when we start adding stuff to `src/finesse_processing`.

For now, if you want these dependencies, you have to run:

```sh
pip install -e .[scripts]
```

I've pinned `numpy` to be at least version 2, as v2 introduced some breaking changes to the API, so we probably don't want users to be using v1. I had a quick look and I *think* the code will also work fine with v1 of numpy, but it'll make our lives easier if we just pick one major version.

@sophiemosselmans You could check that I've got all the dependencies right by making a virtualenv following the instructions in the README and checking that the scripts still work. Up to you though -- I suspect this is fine.